### PR TITLE
CardSO AddType Popup window

### DIFF
--- a/Editor/CardEngineMenu/CreateCardSOWindow.cs
+++ b/Editor/CardEngineMenu/CreateCardSOWindow.cs
@@ -17,7 +17,7 @@ namespace SadSapphicGames.CardEngineEditor {
             cardsDirectory = settings.Directories.CardScriptableObjects;
         }
         private void OnEnable() {
-            cardDatabase = AssetDatabase.LoadAssetAtPath<CardDatabaseSO>("Assets/CardEngine/Config/CardDatabase.asset");
+            cardDatabase = CardDatabaseSO.instance;
         }
         [MenuItem("CardEngine/Create/Card")]
         static void Init() {

--- a/Editor/CardEngineMenu/SelectTypePopup.cs
+++ b/Editor/CardEngineMenu/SelectTypePopup.cs
@@ -12,13 +12,13 @@ namespace SadSapphicGames.CardEngineEditor {
 
         public SelectTypeSOPopup(CardSO target) : base() {
             targetCardSO = target;
-            typeDatabase = AssetDatabase.LoadAssetAtPath<TypeDatabaseSO>("Assets/CardEngine/Config/TypeDatabase.asset");
+            typeDatabase = TypeDatabaseSO.instance;
             typeNames = typeDatabase.GetAllObjectNames();
             typesToAdd = new bool[typeNames.Count];
 
         }
         public override void OnOpen() {
-            Debug.Log($"{typeNames.Count} potential types to add");
+            // Debug.Log($"{typeNames.Count} potential types to add");
         }
 
         public override void OnGUI(Rect rect)
@@ -33,7 +33,8 @@ namespace SadSapphicGames.CardEngineEditor {
                 if(GUILayout.Button("Add Selected Types",EditorStyles.miniButtonLeft)) {
                     for (int i = 0; i < typesToAdd.Length; i++) {
                         if(typesToAdd[i]) {
-                            targetCardSO.AddType(typeDatabase.GetEntryByName(typeNames[i]));
+                            Debug.Log($"Adding type {typeNames[i]} to {targetCardSO.name}");
+                            targetCardSO.AddType((DatabaseEntry<TypeSO>)typeDatabase.GetEntryByName(typeNames[i]));
                         }
                     }
                     editorWindow.Close();

--- a/Editor/CardEngineMenu/SelectTypePopup.cs
+++ b/Editor/CardEngineMenu/SelectTypePopup.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using UnityEditor;
+using SadSapphicGames.CardEngine;
+using System.Collections.Generic;
+
+namespace SadSapphicGames.CardEngineEditor {
+    public class SelectTypeSOPopup : PopupWindowContent {
+        private List<string> typeNames;
+        bool[] typesToAdd;
+        private TypeDatabaseSO typeDatabase;
+        private CardSO targetCardSO;
+
+        public SelectTypeSOPopup(CardSO target) : base() {
+            targetCardSO = target;
+            typeDatabase = AssetDatabase.LoadAssetAtPath<TypeDatabaseSO>("Assets/CardEngine/Config/TypeDatabase.asset");
+            typeNames = typeDatabase.GetAllObjectNames();
+            typesToAdd = new bool[typeNames.Count];
+
+        }
+        public override void OnOpen() {
+            Debug.Log($"{typeNames.Count} potential types to add");
+        }
+
+        public override void OnGUI(Rect rect)
+        {
+            GUILayout.Label("Select Types To Add", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical();
+                for (int i = 0; i < typeNames.Count; i++) {
+                    typesToAdd[i] = EditorGUILayout.Toggle(typeNames[i],typesToAdd[i]);
+                }
+            EditorGUILayout.EndVertical();
+            EditorGUILayout.BeginHorizontal();
+                if(GUILayout.Button("Add Selected Types",EditorStyles.miniButtonLeft)) {
+                    for (int i = 0; i < typesToAdd.Length; i++) {
+                        if(typesToAdd[i]) {
+                            targetCardSO.AddType(typeDatabase.GetEntryByName(typeNames[i]));
+                        }
+                    }
+                    editorWindow.Close();
+                }
+                if(GUILayout.Button("Cancel",EditorStyles.miniButtonRight)) {
+                    editorWindow.Close();
+                }
+            EditorGUILayout.EndHorizontal();
+        }
+        public override Vector2 GetWindowSize()
+        {
+            return new Vector2(200,150);
+        }
+    }
+}

--- a/Editor/CardEngineMenu/SelectTypePopup.cs.meta
+++ b/Editor/CardEngineMenu/SelectTypePopup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75035d42434d3cb41b6ac08fe4de0561
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/CustomSOInspector/CardSOEditor.cs
+++ b/Editor/CustomSOInspector/CardSOEditor.cs
@@ -10,8 +10,9 @@ namespace SadSapphicGames.CardEngineEditor {
     public class CardSOEditor : Editor {
         public override void OnInspectorGUI() {
             base.OnInspectorGUI();
+            Rect buttonRect = new Rect();
             if(GUILayout.Button("Add Type")) {
-                ;
+                PopupWindow.Show(buttonRect, new SelectTypeSOPopup((CardSO)target));
             }
         }
     }

--- a/Runtime/Cards/Card.cs
+++ b/Runtime/Cards/Card.cs
@@ -20,7 +20,7 @@ namespace SadSapphicGames.CardEngine{
         public void LoadData(CardSO cardDataSO) {
             cardData = cardDataSO;
             foreach (var cardTypeSO in cardData.CardTypes) {
-                cardTypeSO.AddTypeTo(this);
+                cardTypeSO.AddTypeToGameObject(this);
             }
             cardNameArea.text = CardName;
             cardDescriptionArea.text = CardText;

--- a/Runtime/SOClasses/CardDatabaseSO.cs
+++ b/Runtime/SOClasses/CardDatabaseSO.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
-using SadSapphicGames.CardEngine;
 
-namespace SadSapphicGames.CardEngineEditor
+namespace SadSapphicGames.CardEngine
 {
-    
-    [CreateAssetMenu(fileName = "CardDatabase", menuName = "SadSapphicGames/CardEngine/Databases/CardDatabase")]
     public class CardDatabaseSO : DatabaseSO<CardSO> {
-        
+        public static CardDatabaseSO instance; 
+        private void OnEnable() {
+            instance = AssetDatabase.LoadAssetAtPath<CardDatabaseSO>("Assets/CardEngine/Config/CardDatabase.asset");
+        }
     }
 }

--- a/Runtime/SOClasses/CardSO.cs
+++ b/Runtime/SOClasses/CardSO.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 
@@ -14,11 +16,32 @@ namespace SadSapphicGames.CardEngine
         public Sprite CardSprite {get => _cardSprite;}
         [SerializeField] private string _cardText;
         public string CardText {get => _cardText; set => _cardText = value;}
-        [SerializeField] private List<TypeSO> _cardTypes;
+        [SerializeField] private List<TypeSO> _cardTypes = new List<TypeSO>();
         public List<TypeSO> CardTypes {get => _cardTypes;}
+        
+        private Dictionary<TypeSO,TypeDataSO> typesSubData = new Dictionary<TypeSO, TypeDataSO>();
 
         public void AddType(DatabaseEntry<TypeSO> typeDatabaseEntry) {
-            CardTypes.Add(typeDatabaseEntry.entrykey);
+            TypeSO typeSO = typeDatabaseEntry.entrykey;
+            Type typeDataSOType = typeSO.TypeDataReference.GetType(); 
+                //? this name is pretty confusing: 
+                //? this is the type of the scriptable object representing the data associated with the card-type we are adding
+            CardTypes.Add(typeSO);
+
+            TypeDataSO typeData = (TypeDataSO)ScriptableObject.CreateInstance(typeDataSOType);
+            typeData.name = $"{CardName}{typeSO.Name}Data";
+            AssetDatabase.CreateAsset(typeData,$"{CardDatabaseSO.instance.GetEntryByKey(this).entryDirectory}/{typeData.name}.asset");
+            typesSubData.Add(typeSO,typeData);
+            
+            AssetDatabase.SaveAssets();
+        }
+        public TypeDataSO GetTypeSubdata(TypeSO type) {
+            if (!CardTypes.Contains(type)) {
+                Debug.LogWarning($"{CardName} does not have type {type.Name}");
+                return null;
+            } else {
+                return typesSubData[type];
+            }
         }
     }
 }

--- a/Runtime/SOClasses/TypeDatabaseSO.cs
+++ b/Runtime/SOClasses/TypeDatabaseSO.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
-using SadSapphicGames.CardEngine;
 
-namespace SadSapphicGames.CardEngineEditor
+
+namespace SadSapphicGames.CardEngine
 {
-    [CreateAssetMenu(fileName = "TypeDatabase", menuName = "SadSapphicGames/CardEngine/Databases/TypeDatabase")]
+
     public class TypeDatabaseSO : DatabaseSO<TypeSO> {
-        
+        public static TypeDatabaseSO instance; 
+        private void OnEnable() {
+            instance = AssetDatabase.LoadAssetAtPath<TypeDatabaseSO>("Assets/CardEngine/Config/TypeDatabase.asset");
+        }
     }
 }

--- a/Runtime/SOClasses/TypeSO.cs
+++ b/Runtime/SOClasses/TypeSO.cs
@@ -20,6 +20,7 @@ namespace SadSapphicGames.CardEngine
         
         // private Type typeComponent  { get => Type.GetType(this.name); }
         private Type typeComponent { get => typeReferencePrefab.GetType();}
+        public TypeDataSO TypeDataReference { get => typeDataReference; }
 
         public void AddTypeToGameObject(Card card) {
             if(typeComponent == null) {throw new Exception($"there is no monobehaviour component associated with {this.name} to add");}

--- a/Runtime/SOClasses/TypeSO.cs
+++ b/Runtime/SOClasses/TypeSO.cs
@@ -21,7 +21,7 @@ namespace SadSapphicGames.CardEngine
         // private Type typeComponent  { get => Type.GetType(this.name); }
         private Type typeComponent { get => typeReferencePrefab.GetType();}
 
-        public void AddTypeTo(Card card) {
+        public void AddTypeToGameObject(Card card) {
             if(typeComponent == null) {throw new Exception($"there is no monobehaviour component associated with {this.name} to add");}
             card.gameObject.AddComponent(typeComponent); 
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "com.sadsapphicgames.cardengine",
-  "version" : "0.2.2",
+  "version" : "0.2.3",
   "displayName" : "CardEngine",
   "description" : "This is an in development package to provide an extensible and generic architecture for card games that can be used across projects",
   "dependencies": {


### PR DESCRIPTION
the CardSO editor now includes a button to open a popup window to add card-types to it. The selected options are added to the CardSO's list of types and have their respective subdata scriptable objects created in the card's directory.