### PR TITLE
Draggable UI behaviour crash bugfix

### DIFF
--- a/Runtime/CardZone/CardZone.cs
+++ b/Runtime/CardZone/CardZone.cs
@@ -13,10 +13,10 @@ namespace SadSapphicGames.CardEngine
         private void Awake() {
             Cards = new List<Card>();
         }
-        public void MoveCard(Card card, CardZone moveToZone) {
+        public void MoveCard(Card card, CardZone moveToZone) { //? might be better to put this method in Card
             if(Cards.Contains(card)) {
                 Cards.Remove(card);
-                moveToZone.AddCard(card);
+                moveToZone.AddCard(card); //? this method will take care of card.CurrentZone as well
             } else {
                 Debug.LogWarning($"Card {card.CardName} not found in cardzone {this.name}");
             }
@@ -25,6 +25,7 @@ namespace SadSapphicGames.CardEngine
 
         public void AddCard(Card card) {
             Cards.Add(card);
+            card.CurrentZone = this;
             card.transform.SetParent(this.transform);
         }
     }

--- a/Runtime/UIBehaviours/Draggable.cs
+++ b/Runtime/UIBehaviours/Draggable.cs
@@ -5,6 +5,7 @@ using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace SadSapphicGames.CardEngine {
+    [RequireComponent(typeof(CanvasGroup))]
     public class Draggable : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHandler {
         [SerializeField] private DropZone dropZone;
         private Card card { get => GetComponent<Card>(); }
@@ -16,7 +17,7 @@ namespace SadSapphicGames.CardEngine {
             CardZone currentZone = card.CurrentZone;
             //! this is slow but it doesnt run every frame so i think its fine, potentially a target for refactoring
             //! breaks if there are multiple Dropzones in the scene
-            dropZone = (DropZone)Resources.FindObjectsOfTypeAll(typeof(DropZone))[0];
+            // dropZone = (DropZone)Resources.FindObjectsOfTypeAll(typeof(DropZone))[0];
         }
         private Vector2 dragOffset;
         private LayoutGroup layoutGroup;
@@ -27,7 +28,7 @@ namespace SadSapphicGames.CardEngine {
         }
     // * IDragHandler
         public void OnBeginDrag(PointerEventData eventData) {
-            dropZone.gameObject.SetActive(true);
+            // dropZone.gameObject.SetActive(true);
             UnityEngine.Debug.Log($"Dragging {GetComponent<Card>().CardName}");
             dragOffset = eventData.position - (Vector2)gameObject.transform.position;
             layoutGroup = gameObject.GetComponentInParent<LayoutGroup>();
@@ -36,7 +37,7 @@ namespace SadSapphicGames.CardEngine {
             if (!CurrentZone.CardsDraggable) { return; }
             gameObject.transform.position = eventData.position - dragOffset;  
         } public void OnEndDrag(PointerEventData eventData) {
-            dropZone.gameObject.SetActive(false);
+            // dropZone.gameObject.SetActive(false);
             UnityEngine.Debug.Log($"{GetComponent<Card>().CardName} dropped");
             dragOffset = Vector2.zero;
             GetComponentInParent<CanvasGroup>().blocksRaycasts = true;


### PR DESCRIPTION
regarding the "Dropzone" lines commented out in commit ac5a4765c704491fb08fa777356582ed38554949 i believe a better approach is an event that fires unless the held card is released over the hand zone. Tangentially is it really necessary for ever zone to have a "CardsDraggable" field? Would this ever be needed in a zone that isnt a HandZone 