### PR TITLE
database data loss bugfix

### DIFF
--- a/Editor/Databases/DatabaseSO.cs
+++ b/Editor/Databases/DatabaseSO.cs
@@ -32,6 +32,7 @@ namespace SadSapphicGames.CardEngineEditor {
             } else {
                 throw new System.Exception($"failed to find directory {parentDirectory} entered for scriptable object {obj.name}");
             }
+            EditorUtility.SetDirty(this);
         }
         private void OnValidate() {
             CleanUp();


### PR DESCRIPTION
adding entries to a database now sets the database as dirty so the changes to it are saved when exiting the unity editor

closes #43 