### PR TITLE
CreateCardType set dirty bugfix

### DIFF
--- a/Editor/CardEngineCreate/CreateCardTypeWindow.cs
+++ b/Editor/CardEngineCreate/CreateCardTypeWindow.cs
@@ -105,6 +105,7 @@ namespace SadSapphicGames.CardEngineEditor {
                 AssetDatabase.CreateAsset(typeDataSO,$"{typesDirectory}/{typeName}/{typeDataSO.name}.asset");
                 typeSO.SetDataReference(typeDataSO);
 
+                EditorUtility.SetDirty(typeSO);
                 AssetDatabase.SaveAssets();
                 this.Close();
             }


### PR DESCRIPTION
the CreateCardType window now sets the marks the type as having been modified so changes are not lost on editor reload