### PR TITLE
InspectorActionsTests

### DIFF
--- a/Editor/CustomSOInspector/CompositeEffectSOEditor.cs
+++ b/Editor/CustomSOInspector/CompositeEffectSOEditor.cs
@@ -28,16 +28,5 @@ public class CompositeEffectSOEditor : Editor {
         serializedObject.Update();
         Repaint();
     }
-    private void AddUnitEffect(UnitEffectSO unitEffect)  {
-            Type subEffectType = unitEffect.GetType();
-            CompositeEffectSO targetObj = (CompositeEffectSO)target;
-            Debug.Log($"adding subeffect {unitEffect.name}");
-            EffectSO subEffectObj = (EffectSO)ScriptableObject.CreateInstance(subEffectType);
-            subEffectObj.name = $"{targetObj.name}Subeffect{targetObj.ChildrenCount + 1}";
-            AssetDatabase.AddObjectToAsset(subEffectObj,AssetDatabase.GetAssetPath(targetObj));
-            targetObj.AddChild(subEffectObj);
-            AssetDatabase.SaveAssets();
-
-    }
 }
 }

--- a/Editor/Databases/DatabaseSO.cs
+++ b/Editor/Databases/DatabaseSO.cs
@@ -76,6 +76,10 @@ namespace SadSapphicGames.CardEngineEditor {
             outEntry = null; 
             return false;
         }
+        public DatabaseEntry<TScriptableObject> GetRandomEntry(){
+            int randomIndex = Random.Range(0,database.Count);
+            return database[randomIndex];
+        }
         public DatabaseEntry<TScriptableObject> GetEntryByKey(TScriptableObject obj, bool suppressWarning = false) {
             if(ContainsKey(obj, out var entry)) {
                 return entry;

--- a/Editor/PopupWindows/AddEffectPopup.cs
+++ b/Editor/PopupWindows/AddEffectPopup.cs
@@ -26,12 +26,8 @@ namespace SadSapphicGames.CardEngineEditor {
             for (int i = 0; i < effectsToAdd.Length; i++) {
                 if(effectsToAdd[i]) {
                     Debug.Log($"Adding subeffect {effectNames[i]} to {targetEffect.name}");
-                    DatabaseEntry<EffectSO> effectEntry = effectDatabase.GetEntryByName(effectNames[i]);
-                    EffectSO effectClone = (EffectSO)ScriptableObject.CreateInstance(effectEntry.entrykey.GetType());
-                    effectClone.name = $"{targetEffect.name}{effectNames[i]}";
-                    AssetDatabase.AddObjectToAsset(effectClone, AssetDatabase.GetAssetPath(targetEffect));
-                    targetEffect.AddChild(effectClone);
-                    AssetDatabase.SaveAssets();
+                    targetEffect.AddChildEffect(effectDatabase.GetEntryByName(effectNames[i]).entrykey);
+                    
                 }
             }
             EditorUtility.SetDirty(targetEffect);

--- a/Editor/PopupWindows/AddTypePopup.cs
+++ b/Editor/PopupWindows/AddTypePopup.cs
@@ -12,6 +12,9 @@ namespace SadSapphicGames.CardEngineEditor {
         public List<string> typeNames;
 
         public AddTypeObject(CardSO _targetCardSO) {
+            if(_targetCardSO == null) {
+                throw new ArgumentNullException();
+            }
             targetCardSO = _targetCardSO;
             typeDatabase = TypeDatabaseSO.Instance;
             typeNames = typeDatabase.GetAllObjectNames();

--- a/Runtime/CardEffects/CompositeEffectSO.cs
+++ b/Runtime/CardEffects/CompositeEffectSO.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using UnityEditor;
 using UnityEngine;
 
 namespace SadSapphicGames.CardEngine
@@ -14,8 +15,12 @@ namespace SadSapphicGames.CardEngine
                 effect.ResolveEffect();                
             }
         }
-        public void AddChild(EffectSO childEffect) {
-            subEffects.Add(childEffect);
+        public void AddChildEffect(EffectSO desiredEffect) {
+            EffectSO effectClone = (EffectSO)ScriptableObject.CreateInstance(desiredEffect.GetType());
+            effectClone.name = $"{this.name}{desiredEffect.name}Subeffect";
+            AssetDatabase.AddObjectToAsset(effectClone,AssetDatabase.GetAssetPath(this));
+            subEffects.Add(effectClone);
+            AssetDatabase.SaveAssets();
         }
         public void RemoveChild(EffectSO childEffect) {
             if(subEffects.Remove(childEffect)) {

--- a/Tests/EditorTests/CreateMenuTests.cs
+++ b/Tests/EditorTests/CreateMenuTests.cs
@@ -84,6 +84,11 @@ public class CreateMenuTests : IPostBuildCleanup
         Assert.AreEqual(expected:testCardName, actual: testCard.CardName);
         Assert.AreEqual(expected:"test card text", actual: testCard.CardText);
     }
+
+//! The following tests are probably bad practice as they require the previous test to have been run first
+//! however its easier to test it like this as the alternative is generating a new test card for each test
+//! which couples the functionality we are testing here to the functionality of the create card menu
+
     [Test, Order(3)]
     public void AddTypeTest(){
         //? Load card
@@ -106,5 +111,30 @@ public class CreateMenuTests : IPostBuildCleanup
         //? Verify the subdata is being added appropriately
         Object typeSubdata = AssetDatabase.LoadAllAssetsAtPath($"{cardsDirectory}/{testCardName}/{testCardName}.asset")[0];
         Assert.AreEqual(expected: typeSubdata, actual: testCard.GetTypeSubdata(addedType));
+    }
+
+    [Test, Order(4)]
+    public void RemoveTypeTest() {
+        //? Load card
+        CardSO testCard = AssetDatabase.LoadAssetAtPath<CardSO>($"{cardsDirectory}/{testCardName}/{testCardName}.asset");
+        
+        //? Create remove type object
+        RemoveTypeObject removeTypeObject = new RemoveTypeObject(testCard);
+
+        //? Identify the type to remove
+        bool[] typesToRemove = new bool[testCard.CardTypes.Count];
+        int typeIndex = Random.Range(0,testCard.CardTypes.Count -1); //? there should only be one option here
+        TypeSO removedType = testCard.CardTypes[typeIndex];
+        typesToRemove[typeIndex] = true;
+
+        //? Remove type
+        removeTypeObject.RemoveTypes(typesToRemove);
+        
+        //? verify type has been removed
+        Assert.IsFalse(testCard.HasType(removedType));
+
+        //? verify subdata has been removed
+        //? if we change this test to involved a card with multiple types we will need to rework this line
+        Assert.AreEqual(expected: testCard, actual: AssetDatabase.LoadAllAssetsAtPath($"{cardsDirectory}/{testCardName}/{testCardName}.asset")[0]); 
     }
 }

--- a/Tests/EditorTests/CreateMenuTests.cs
+++ b/Tests/EditorTests/CreateMenuTests.cs
@@ -7,6 +7,7 @@ using SadSapphicGames.CardEngineEditor;
 using SadSapphicGames.CardEngine;
 using UnityEditor;
 
+// ! MAKE SURE YOU RUN ALL TESTS - later tests use assets created my earlier ones
 public class CreateMenuTests : IPostBuildCleanup
 {
     //? Directories
@@ -19,6 +20,8 @@ public class CreateMenuTests : IPostBuildCleanup
     CreateUnitEffectObject createUnitEffectObject = new CreateUnitEffectObject();
     CreateCardObject createCardObject = new CreateCardObject();
 
+
+
     //? Test asset names
     string testTypeName = "TestType";
     string testEffectName = "TestEffect";
@@ -30,7 +33,7 @@ public class CreateMenuTests : IPostBuildCleanup
         AssetDatabase.DeleteAsset($"{cardsDirectory}/{testCardName}");
     }
 
-    [UnityTest]
+    [UnityTest, Order(0)]
     public IEnumerator CreateCardTypeTest() {
         //? create a card type
         createCardTypeObject.CreateCardType(testTypeName);
@@ -51,9 +54,9 @@ public class CreateMenuTests : IPostBuildCleanup
         Assert.AreEqual(expected: testTypeData, actual: testType.TypeDataReference);
         Assert.AreEqual(expected: testTypeComponent.GetType(), actual: testType.typeComponent);
     }
-    [UnityTest]
+    [UnityTest, Order(1)]
     public IEnumerator CreateUnitEffectTest() {
-        //? create a unity effect
+        //? create a unit effect
         createUnitEffectObject.CreateUnitEffect(testEffectName);
         yield return new RecompileScripts();
 
@@ -64,7 +67,7 @@ public class CreateMenuTests : IPostBuildCleanup
         //? verify the effect was found
         Assert.IsNotNull(testEffect);
     }
-    [Test]
+    [Test, Order(2)]
     public void CreateCardTest(){
         //? Create the card
         createCardObject.CreateCard(testCardName,"test card text");
@@ -80,5 +83,28 @@ public class CreateMenuTests : IPostBuildCleanup
         //? Verify fields where assigned properly
         Assert.AreEqual(expected:testCardName, actual: testCard.CardName);
         Assert.AreEqual(expected:"test card text", actual: testCard.CardText);
+    }
+    [Test, Order(3)]
+    public void AddTypeTest(){
+        //? Load card
+        CardSO testCard = AssetDatabase.LoadAssetAtPath<CardSO>($"{cardsDirectory}/{testCardName}/{testCardName}.asset");
+        
+        //? Create add card object and an array to use as an argument
+        AddTypeObject addTypeObject = new AddTypeObject(testCard);
+        List<string> typeNames = TypeDatabaseSO.Instance.GetAllObjectNames();
+        bool[] typesToAdd = new bool[typeNames.Count];
+        int typeIndex = Random.Range(0,typeNames.Count-1);
+        typesToAdd[typeIndex] = true;
+        
+        //? get what the type to be added is and add it to the card
+        TypeSO addedType = TypeDatabaseSO.Instance.GetEntryByName(typeNames[typeIndex]).entrykey;
+        addTypeObject.AddTypes(typesToAdd);
+
+        //? Verify that the card has the added type
+        Assert.IsTrue(testCard.HasType(addedType));
+
+        //? Verify the subdata is being added appropriately
+        Object typeSubdata = AssetDatabase.LoadAllAssetsAtPath($"{cardsDirectory}/{testCardName}/{testCardName}.asset")[0];
+        Assert.AreEqual(expected: typeSubdata, actual: testCard.GetTypeSubdata(addedType));
     }
 }

--- a/Tests/EditorTests/CreateMenuTests.cs
+++ b/Tests/EditorTests/CreateMenuTests.cs
@@ -83,11 +83,8 @@ public class CreateMenuTests : IPostBuildCleanup
         //? Verify fields where assigned properly
         Assert.AreEqual(expected:testCardName, actual: testCard.CardName);
         Assert.AreEqual(expected:"test card text", actual: testCard.CardText);
+        Assert.AreEqual(expected:testCardEffect, actual: testCard.CardEffect);
     }
-
-//! The following tests are probably bad practice as they require the previous test to have been run first
-//! however its easier to test it like this as the alternative is generating a new test card for each test
-//! which couples the functionality we are testing here to the functionality of the create card menu
 
     [Test, Order(3)]
     public void AddTypeTest(){
@@ -113,28 +110,5 @@ public class CreateMenuTests : IPostBuildCleanup
         Assert.AreEqual(expected: typeSubdata, actual: testCard.GetTypeSubdata(addedType));
     }
 
-    [Test, Order(4)]
-    public void RemoveTypeTest() {
-        //? Load card
-        CardSO testCard = AssetDatabase.LoadAssetAtPath<CardSO>($"{cardsDirectory}/{testCardName}/{testCardName}.asset");
-        
-        //? Create remove type object
-        RemoveTypeObject removeTypeObject = new RemoveTypeObject(testCard);
-
-        //? Identify the type to remove
-        bool[] typesToRemove = new bool[testCard.CardTypes.Count];
-        int typeIndex = Random.Range(0,testCard.CardTypes.Count -1); //? there should only be one option here
-        TypeSO removedType = testCard.CardTypes[typeIndex];
-        typesToRemove[typeIndex] = true;
-
-        //? Remove type
-        removeTypeObject.RemoveTypes(typesToRemove);
-        
-        //? verify type has been removed
-        Assert.IsFalse(testCard.HasType(removedType));
-
-        //? verify subdata has been removed
-        //? if we change this test to involved a card with multiple types we will need to rework this line
-        Assert.AreEqual(expected: testCard, actual: AssetDatabase.LoadAllAssetsAtPath($"{cardsDirectory}/{testCardName}/{testCardName}.asset")[0]); 
-    }
+    
 }

--- a/Tests/EditorTests/CreateMenuTests.cs
+++ b/Tests/EditorTests/CreateMenuTests.cs
@@ -7,7 +7,6 @@ using SadSapphicGames.CardEngineEditor;
 using SadSapphicGames.CardEngine;
 using UnityEditor;
 
-// ! MAKE SURE YOU RUN ALL TESTS - later tests use assets created my earlier ones
 public class CreateMenuTests : IPostBuildCleanup
 {
     //? Directories
@@ -86,29 +85,7 @@ public class CreateMenuTests : IPostBuildCleanup
         Assert.AreEqual(expected:testCardEffect, actual: testCard.CardEffect);
     }
 
-    [Test, Order(3)]
-    public void AddTypeTest(){
-        //? Load card
-        CardSO testCard = AssetDatabase.LoadAssetAtPath<CardSO>($"{cardsDirectory}/{testCardName}/{testCardName}.asset");
-        
-        //? Create add card object and an array to use as an argument
-        AddTypeObject addTypeObject = new AddTypeObject(testCard);
-        List<string> typeNames = TypeDatabaseSO.Instance.GetAllObjectNames();
-        bool[] typesToAdd = new bool[typeNames.Count];
-        int typeIndex = Random.Range(0,typeNames.Count-1);
-        typesToAdd[typeIndex] = true;
-        
-        //? get what the type to be added is and add it to the card
-        TypeSO addedType = TypeDatabaseSO.Instance.GetEntryByName(typeNames[typeIndex]).entrykey;
-        addTypeObject.AddTypes(typesToAdd);
 
-        //? Verify that the card has the added type
-        Assert.IsTrue(testCard.HasType(addedType));
-
-        //? Verify the subdata is being added appropriately
-        Object typeSubdata = AssetDatabase.LoadAllAssetsAtPath($"{cardsDirectory}/{testCardName}/{testCardName}.asset")[0];
-        Assert.AreEqual(expected: typeSubdata, actual: testCard.GetTypeSubdata(addedType));
-    }
 
     
 }

--- a/Tests/EditorTests/InspectorActionsTest.cs
+++ b/Tests/EditorTests/InspectorActionsTest.cs
@@ -1,0 +1,71 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using SadSapphicGames.CardEngineEditor;
+using SadSapphicGames.CardEngine;
+using UnityEditor;
+public class InspectorActionsTest : IPrebuildSetup, IPostBuildCleanup{
+    CardSO testCard;
+    CompositeEffectSO testCompEffect;
+
+    public void Setup() {
+        //? generate the test card and its composite effect 
+        //? as well as a test type and test unit effect
+        //? to make sure both databases have at least one entry
+        throw new System.NotImplementedException();
+    }
+
+    public void Cleanup() {
+        throw new System.NotImplementedException();
+    }
+    [Test]
+    public void RemoveTypeTest() {
+
+        
+        //? Create remove type object
+        RemoveTypeObject removeTypeObject = new RemoveTypeObject(testCard);
+
+        //? Identify the type to remove
+        bool[] typesToRemove = new bool[testCard.CardTypes.Count];
+        int typeIndex = Random.Range(0,testCard.CardTypes.Count -1); //? there should only be one option here
+        TypeSO removedType = testCard.CardTypes[typeIndex];
+        typesToRemove[typeIndex] = true;
+
+        //? Remove type
+        removeTypeObject.RemoveTypes(typesToRemove);
+        
+        //? verify type has been removed
+        Assert.IsFalse(testCard.HasType(removedType));
+
+        //? verify subdata has been removed
+        //? if we change this test to involved a card with multiple types we will need to rework this line
+        Assert.AreEqual(expected: testCard, actual: AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(testCard))[0]); 
+    }
+    [Test]
+    public void AddEffectTest() {
+        //? Load composite effect
+
+
+        //?create Add effect object and the array argument
+        AddEffectObject addEffectObject = new AddEffectObject(testCompEffect);
+        List<string> effectNames = EffectDatabaseSO.Instance.GetAllObjectNames();
+        bool[] effectsToAdd = new bool[effectNames.Count];
+        int effectIndex = Random.Range(0, effectNames.Count - 1); 
+        EffectSO addedEffect = EffectDatabaseSO.Instance.GetEntryByName(effectNames[effectIndex]).entrykey;
+        effectsToAdd[effectIndex] = true;
+
+        //? Add effects to composite
+        addEffectObject.AddEffects(effectsToAdd);
+
+        //? verify the effect has been added correctly
+        Assert.AreEqual(expected:addedEffect.GetType(), actual: testCompEffect.Subeffects[0].GetType());
+        Assert.AreEqual(
+            expected: testCompEffect.Subeffects[0],
+            actual: AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(testCompEffect))[0]
+        );
+    }
+
+
+}

--- a/Tests/EditorTests/InspectorActionsTest.cs
+++ b/Tests/EditorTests/InspectorActionsTest.cs
@@ -16,14 +16,10 @@ public class InspectorActionsTest : IPrebuildSetup, IPostBuildCleanup{
     CardSO testCard;
     CompositeEffectSO testCompEffect;
 
-    
-
     public void Setup() {
         //? generate the test card and its composite effect 
         CreateCardObject createCardObject = new CreateCardObject();
         createCardObject.CreateCard("TestCard", "Test Card Text");
-        testCard = AssetDatabase.LoadAssetAtPath<CardSO>($"{cardsDirectory}/TestCard/TestCard.asset");
-        testCompEffect = AssetDatabase.LoadAssetAtPath<CompositeEffectSO>($"{cardsDirectory}/TestCard/TestCardEffect.asset");
         
         //? Make sure the type and unit effect databases have atleast one entry
         if(
@@ -32,8 +28,6 @@ public class InspectorActionsTest : IPrebuildSetup, IPostBuildCleanup{
         ) {
             throw new System.Exception("There must be at least one entry in the type and effect databases each to test inspector actions");
         }
-
-        
     }
 
     public void Cleanup() {
@@ -41,6 +35,7 @@ public class InspectorActionsTest : IPrebuildSetup, IPostBuildCleanup{
     }
     [Test]
     public void AddTypeTest(){
+        testCard = AssetDatabase.LoadAssetAtPath<CardSO>($"{cardsDirectory}/TestCard/TestCard.asset");
         
         //? Create add card object and an array to use as an argument
         //? we pick a random type to add
@@ -63,7 +58,7 @@ public class InspectorActionsTest : IPrebuildSetup, IPostBuildCleanup{
     }
     [Test]
     public void RemoveTypeTest() {
-
+        testCard = AssetDatabase.LoadAssetAtPath<CardSO>($"{cardsDirectory}/TestCard/TestCard.asset");
         
         //? Create remove type object
         RemoveTypeObject removeTypeObject = new RemoveTypeObject(testCard);
@@ -87,6 +82,7 @@ public class InspectorActionsTest : IPrebuildSetup, IPostBuildCleanup{
     [Test]
     public void AddEffectTest() {
         //? Load composite effect
+        testCompEffect = AssetDatabase.LoadAssetAtPath<CompositeEffectSO>($"{cardsDirectory}/TestCard/TestCardEffect.asset");
 
 
         //?create Add effect object and the array argument

--- a/Tests/EditorTests/InspectorActionsTest.cs
+++ b/Tests/EditorTests/InspectorActionsTest.cs
@@ -60,6 +60,10 @@ public class InspectorActionsTest : IPrebuildSetup, IPostBuildCleanup{
     public void RemoveTypeTest() {
         testCard = AssetDatabase.LoadAssetAtPath<CardSO>($"{cardsDirectory}/TestCard/TestCard.asset");
         
+        //? add a random type to the test card to make sure it has atleast one
+        TypeSO randomCardType = TypeDatabaseSO.Instance.GetRandomEntry().entrykey;
+        testCard.AddType(randomCardType);
+        
         //? Create remove type object
         RemoveTypeObject removeTypeObject = new RemoveTypeObject(testCard);
 

--- a/Tests/EditorTests/InspectorActionsTest.cs.meta
+++ b/Tests/EditorTests/InspectorActionsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22f4a12c36637ce4694c2b45518d0777
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
adds tests for the add/remove type and effect inspector actions through testing their respective popup window's objects. All tests are independent of each other and can be run without first running a different test

close #52 